### PR TITLE
fix: Fixed build failure for Xcode 12.5

### DIFF
--- a/XCFit.xcodeproj/project.pbxproj
+++ b/XCFit.xcodeproj/project.pbxproj
@@ -225,6 +225,7 @@
 			buildSettings = {
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
@@ -250,6 +251,7 @@
 			buildSettings = {
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",


### PR DESCRIPTION
https://developer.apple.com/documentation/xcode-release-notes/xcode-12_5-release-notes
> Xcode no longer includes XCTest’s legacy Swift overlay library (libswiftXCTest.dylib). Use the library’s replacement, libXCTestSwiftSupport.dylib, instead. For frameworks that encounter build issues because of the removal of the legacy library, delete the framework and library search paths for libswiftXCTest.dylib and add the ENABLE_TESTING_SEARCH_PATHS=YES build setting. This setting automatically sets the target’s search paths so that it can locate the replacement XCTest library. (70365050)